### PR TITLE
Handle variable audio sample rate

### DIFF
--- a/arguments_classes/module_arguments.py
+++ b/arguments_classes/module_arguments.py
@@ -44,3 +44,9 @@ class ModuleArguments:
             "help": "Provide logging level. Example --log_level debug, default=info."
         },
     )
+    input_sample_rate: int = field(
+        default=16000,
+        metadata={
+            "help": "Sample rate of incoming audio from the client. Audio is resampled to 16 kHz internally.",
+        },
+    )

--- a/resample_handler.py
+++ b/resample_handler.py
@@ -1,0 +1,21 @@
+import numpy as np
+import librosa
+import logging
+from baseHandler import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+class ResampleHandler(BaseHandler):
+    """Resamples incoming audio to a fixed sample rate."""
+
+    def setup(self, input_rate: int = 16000, output_rate: int = 16000):
+        self.input_rate = input_rate
+        self.output_rate = output_rate
+
+    def process(self, audio_chunk: bytes):
+        audio = np.frombuffer(audio_chunk, dtype=np.int16).astype(np.float32) / 32768.0
+        if self.input_rate != self.output_rate:
+            audio = librosa.resample(audio, orig_sr=self.input_rate, target_sr=self.output_rate)
+        audio = (audio * 32768.0).astype(np.int16)
+        yield audio.tobytes()
+

--- a/s2s_pipeline.py
+++ b/s2s_pipeline.py
@@ -34,6 +34,7 @@ from transformers import (
 )
 
 from AEC.livekit_aec_handler import LivekitAecHandler
+from resample_handler import ResampleHandler
 from STT.openai_whisper_handler import OpenAITTSHandler
 
 from utils.thread_manager import ThreadManager
@@ -212,6 +213,7 @@ def initialize_queues_and_events():
         "stop_event": Event(),
         "should_listen": Event(),
         "recv_audio_chunks_queue": Queue(),
+        "resampled_audio_chunks_queue": Queue(),
         "aec_to_vad_queue": Queue(),
         "send_audio_chunks_queue": Queue(),
         "spoken_prompt_queue": Queue(),
@@ -240,6 +242,7 @@ def build_pipeline(
     stop_event = queues_and_events["stop_event"]
     should_listen = queues_and_events["should_listen"]
     recv_audio_chunks_queue = queues_and_events["recv_audio_chunks_queue"]
+    resampled_audio_chunks_queue = queues_and_events["resampled_audio_chunks_queue"]
     send_audio_chunks_queue = queues_and_events["send_audio_chunks_queue"]
     spoken_prompt_queue = queues_and_events["spoken_prompt_queue"]
     text_prompt_queue = queues_and_events["text_prompt_queue"]
@@ -275,9 +278,18 @@ def build_pipeline(
         ]
 
     # I know it's ugly, but for now let's make it ez
-    aec = LivekitAecHandler(
+    resampler = ResampleHandler(
         stop_event,
         queue_in=recv_audio_chunks_queue,
+        queue_out=resampled_audio_chunks_queue,
+        setup_kwargs=dict(
+            input_rate=module_kwargs.input_sample_rate,
+            output_rate=16000,
+        ),
+    )
+    aec = LivekitAecHandler(
+        stop_event,
+        queue_in=resampled_audio_chunks_queue,
         queue_out=aec_to_vad_queue
     )
     vad = VADHandler(
@@ -299,7 +311,7 @@ def build_pipeline(
         queue_out=text_prompt_queue
     )
 
-    return ThreadManager([*comms_handlers, aec, vad, stt, lm, tts])
+    return ThreadManager([*comms_handlers, resampler, aec, vad, stt, lm, tts])
 
 
 def get_stt_handler(module_kwargs, stop_event, spoken_prompt_queue, text_prompt_queue, whisper_stt_handler_kwargs, faster_whisper_stt_handler_kwargs, paraformer_stt_handler_kwargs):


### PR DESCRIPTION
## Summary
- allow configuring `input_sample_rate`
- resample incoming audio before AEC
- add simple `ResampleHandler`

## Testing
- `python -m py_compile resample_handler.py s2s_pipeline.py arguments_classes/module_arguments.py`
- `pytest -q` *(fails: no tests / deps)*

------
https://chatgpt.com/codex/tasks/task_e_683d0e385350832f955963dd02d4fa8b