### PR TITLE
Add asynchronous model service modules

### DIFF
--- a/=1.40.1
+++ b/=1.40.1
@@ -1,0 +1,29 @@
+Collecting openai
+  Downloading openai-1.82.1-py3-none-any.whl.metadata (25 kB)
+Requirement already satisfied: anyio<5,>=3.5.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from openai) (4.9.0)
+Collecting distro<2,>=1.7.0 (from openai)
+  Downloading distro-1.9.0-py3-none-any.whl.metadata (6.8 kB)
+Collecting httpx<1,>=0.23.0 (from openai)
+  Using cached httpx-0.28.1-py3-none-any.whl.metadata (7.1 kB)
+Collecting jiter<1,>=0.4.0 (from openai)
+  Downloading jiter-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (5.2 kB)
+Requirement already satisfied: pydantic<3,>=1.9.0 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from openai) (1.10.15)
+Requirement already satisfied: sniffio in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from openai) (1.3.1)
+Requirement already satisfied: tqdm>4 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from openai) (4.67.1)
+Requirement already satisfied: typing-extensions<5,>=4.11 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from openai) (4.13.2)
+Requirement already satisfied: idna>=2.8 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from anyio<5,>=3.5.0->openai) (3.10)
+Collecting certifi (from httpx<1,>=0.23.0->openai)
+  Using cached certifi-2025.4.26-py3-none-any.whl.metadata (2.5 kB)
+Collecting httpcore==1.* (from httpx<1,>=0.23.0->openai)
+  Using cached httpcore-1.0.9-py3-none-any.whl.metadata (21 kB)
+Requirement already satisfied: h11>=0.16 in /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->openai) (0.16.0)
+Downloading openai-1.82.1-py3-none-any.whl (720 kB)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 720.5/720.5 kB 15.5 MB/s eta 0:00:00
+Downloading distro-1.9.0-py3-none-any.whl (20 kB)
+Using cached httpx-0.28.1-py3-none-any.whl (73 kB)
+Using cached httpcore-1.0.9-py3-none-any.whl (78 kB)
+Downloading jiter-0.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (352 kB)
+Using cached certifi-2025.4.26-py3-none-any.whl (159 kB)
+Installing collected packages: jiter, distro, certifi, httpcore, httpx, openai
+
+Successfully installed certifi-2025.4.26 distro-1.9.0 httpcore-1.0.9 httpx-0.28.1 jiter-0.10.0 openai-1.82.1

--- a/README.md
+++ b/README.md
@@ -73,6 +73,39 @@ If you want to use Melo TTS, you also need to run:
 python -m unidic download
 ```
 
+## Model Service API
+
+To support concurrent multi-user workloads the repository provides
+thread‑safe service modules for both Whisper (STT) and TTS models.
+Models are loaded once per unique configuration and shared across
+all service instances.  Each service exposes a ``submit`` method to
+enqueue work with a callback that receives the generated result.
+
+```python
+from services.stt_service import WhisperService
+
+def on_result(text: str) -> None:
+    print("transcribed:", text)
+
+stt = WhisperService(model_name="large-v3", device="cuda")
+stt.submit(audio_bytes, on_result)
+```
+
+An equivalent ``TTSService`` is available for text-to-speech models.
+
+### Multi-user Server
+
+`multi_user_server.py` exposes a simple socket server that spawns an
+independent pipeline for every connecting client.  Heavy STT and TTS
+models are shared via the model services so each session only creates
+lightweight handler threads.
+
+Run the server and connect multiple clients simultaneously:
+
+```bash
+python multi_user_server.py
+```
+
 
 ## Usage
 

--- a/STT/openai_whisper_handler.py
+++ b/STT/openai_whisper_handler.py
@@ -11,7 +11,7 @@ from openai import OpenAI
 
 logger = logging.getLogger(__name__)
 
-class OpenAIWhisperHandler(BaseHandler):
+class OpenAITTSHandler(BaseHandler):
     """
     OpenAI Whisper / GPT-4o Transcription Handler (non-streaming chunks)
     """

--- a/STT/service_faster_whisper_handler.py
+++ b/STT/service_faster_whisper_handler.py
@@ -1,0 +1,31 @@
+import queue
+import logging
+from typing import Any
+from rich.console import Console
+
+from baseHandler import BaseHandler
+from services.stt_service import WhisperService
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+class ServiceFasterWhisperSTTHandler(BaseHandler):
+    """STT handler using :class:`WhisperService` for shared inference."""
+
+    def setup(
+        self,
+        model_name: str = "tiny.en",
+        device: str = "auto",
+        compute_type: str = "auto",
+        gen_kwargs: dict | None = None,
+    ) -> None:
+        self.queue: "queue.Queue[str]" = queue.Queue()
+        self.service = WhisperService(model_name, device, compute_type, gen_kwargs or {})
+
+    def process(self, audio: Any):
+        self.service.submit(audio, self.queue.put)
+        text = self.queue.get()
+        if text:
+            console.print(f"[yellow]USER: {text}")
+            yield text

--- a/TTS/service_melo_handler.py
+++ b/TTS/service_melo_handler.py
@@ -1,0 +1,87 @@
+import queue
+import logging
+import librosa
+import numpy as np
+from typing import Any, Tuple
+from rich.console import Console
+
+from melo.api import TTS
+from baseHandler import BaseHandler
+from services.tts_service import TTSService
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+WHISPER_LANGUAGE_TO_MELO_LANGUAGE = {
+    "en": "EN",
+    "fr": "FR",
+    "es": "ES",
+    "zh": "ZH",
+    "ja": "JP",
+    "ko": "KR",
+}
+
+WHISPER_LANGUAGE_TO_MELO_SPEAKER = {
+    "en": "EN-BR",
+    "fr": "FR",
+    "es": "ES",
+    "zh": "ZH",
+    "ja": "JP",
+    "ko": "KR",
+}
+
+
+class ServiceMeloTTSHandler(BaseHandler):
+    """TTS handler using :class:`TTSService` for shared Melo models."""
+
+    def setup(
+        self,
+        should_listen,
+        device: str = "mps",
+        language: str = "en",
+        speaker_to_id: str = "en",
+        blocksize: int = 512,
+    ) -> None:
+        self.should_listen = should_listen
+        self.device = device
+        self.blocksize = blocksize
+        self.language = language
+        self.speaker_to_id = speaker_to_id
+        self.service = self._create_service(language, speaker_to_id)
+        self.queue: "queue.Queue[np.ndarray]" = queue.Queue()
+
+    def _create_service(self, language: str, speaker_to_id: str) -> TTSService:
+        def loader() -> Tuple[TTS, int]:
+            model = TTS(
+                language=WHISPER_LANGUAGE_TO_MELO_LANGUAGE[language],
+                device=self.device,
+            )
+            spk = model.hps.data.spk2id[WHISPER_LANGUAGE_TO_MELO_SPEAKER[speaker_to_id]]
+            return model, spk
+
+        def generate(model_tuple: Tuple[TTS, int], text: str) -> np.ndarray:
+            model, spk = model_tuple
+            audio = model.tts_to_file(text, spk, quiet=True)
+            audio = librosa.resample(audio, orig_sr=44100, target_sr=16000)
+            return (audio * 32768).astype(np.int16)
+
+        return TTSService(("melo", language, self.device), loader, generate)
+
+    def process(self, llm_sentence: Any):
+        language_code = None
+        if isinstance(llm_sentence, tuple):
+            llm_sentence, language_code = llm_sentence
+        if language_code and language_code != self.language:
+            self.language = language_code
+            self.service = self._create_service(language_code, language_code)
+        self.service.submit(str(llm_sentence), self.queue.put)
+        audio = self.queue.get()
+        if len(audio) == 0:
+            self.should_listen.set()
+            return
+        for i in range(0, len(audio), self.blocksize):
+            chunk = audio[i : i + self.blocksize]
+            if len(chunk) < self.blocksize:
+                chunk = np.pad(chunk, (0, self.blocksize - len(chunk)))
+            yield chunk
+        self.should_listen.set()

--- a/connections/stream_connection.py
+++ b/connections/stream_connection.py
@@ -1,0 +1,57 @@
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectionReceiver:
+    """Read fixed-size audio chunks from an existing socket."""
+
+    def __init__(self, stop_event, queue_out, should_listen, conn, chunk_size: int = 1024):
+        self.stop_event = stop_event
+        self.queue_out = queue_out
+        self.should_listen = should_listen
+        self.conn = conn
+        self.chunk_size = chunk_size
+
+    def receive_full_chunk(self) -> Optional[bytes]:
+        data = b""
+        while len(data) < self.chunk_size:
+            packet = self.conn.recv(self.chunk_size - len(data))
+            if not packet:
+                return None
+            data += packet
+        return data
+
+    def run(self):
+        self.should_listen.set()
+        while not self.stop_event.is_set():
+            audio_chunk = self.receive_full_chunk()
+            if audio_chunk is None:
+                self.stop_event.set()
+                self.queue_out.put(b"END")
+                break
+            if self.should_listen.is_set():
+                self.queue_out.put(audio_chunk)
+        logger.info("Receiver closed")
+
+
+class ConnectionSender:
+    """Send audio chunks from a queue over a socket."""
+
+    def __init__(self, stop_event, queue_in, conn):
+        self.stop_event = stop_event
+        self.queue_in = queue_in
+        self.conn = conn
+
+    def run(self):
+        while not self.stop_event.is_set():
+            audio_chunk = self.queue_in.get()
+            try:
+                self.conn.sendall(audio_chunk)
+            except Exception:
+                self.stop_event.set()
+                break
+            if isinstance(audio_chunk, bytes) and audio_chunk == b"END":
+                break
+        logger.info("Sender closed")

--- a/multi_user_server.py
+++ b/multi_user_server.py
@@ -1,0 +1,138 @@
+import socket
+import threading
+import logging
+from typing import Tuple
+
+from VAD.vad_handler import VADHandler
+from AEC.livekit_aec_handler import LivekitAecHandler
+from resample_handler import ResampleHandler
+
+from connections.stream_connection import ConnectionReceiver, ConnectionSender
+from utils.thread_manager import ThreadManager
+from STT.service_faster_whisper_handler import ServiceFasterWhisperSTTHandler
+from TTS.service_melo_handler import ServiceMeloTTSHandler
+from s2s_pipeline import (
+    parse_arguments,
+    prepare_all_args,
+    get_llm_handler,
+    rename_args,
+    optimal_mac_settings,
+    check_mac_settings,
+    overwrite_device_argument,
+    initialize_queues_and_events,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ClientHandler(threading.Thread):
+    def __init__(self, conn: socket.socket, args: Tuple):
+        super().__init__(daemon=True)
+        (
+            module_kwargs,
+            socket_receiver_kwargs,
+            socket_sender_kwargs,
+            vad_handler_kwargs,
+            whisper_stt_handler_kwargs,
+            paraformer_stt_handler_kwargs,
+            faster_whisper_stt_handler_kwargs,
+            language_model_handler_kwargs,
+            open_api_language_model_handler_kwargs,
+            mlx_language_model_handler_kwargs,
+            parler_tts_handler_kwargs,
+            melo_tts_handler_kwargs,
+            chat_tts_handler_kwargs,
+            facebook_mms_tts_handler_kwargs,
+        ) = args
+        self.conn = conn
+        self.kwargs = dict(
+            module_kwargs=module_kwargs,
+            vad_handler_kwargs=vad_handler_kwargs,
+            faster_whisper_stt_handler_kwargs=faster_whisper_stt_handler_kwargs,
+            language_model_handler_kwargs=language_model_handler_kwargs,
+            open_api_language_model_handler_kwargs=open_api_language_model_handler_kwargs,
+            mlx_language_model_handler_kwargs=mlx_language_model_handler_kwargs,
+            melo_tts_handler_kwargs=melo_tts_handler_kwargs,
+        )
+
+    def run(self):
+        q = initialize_queues_and_events()
+        stop_event = q["stop_event"]
+        should_listen = q["should_listen"]
+        interrupt_event = q["interrupt_event"]
+
+        receiver = ConnectionReceiver(
+            stop_event,
+            q["recv_audio_chunks_queue"],
+            should_listen,
+            self.conn,
+            chunk_size=1024,
+        )
+        sender = ConnectionSender(stop_event, q["send_audio_chunks_queue"], self.conn)
+        aec = LivekitAecHandler(
+            stop_event,
+            queue_in=q["recv_audio_chunks_queue"],
+            queue_out=q["aec_to_vad_queue"],
+        )
+        vad = VADHandler(
+            stop_event,
+            queue_in=q["aec_to_vad_queue"],
+            queue_out=q["spoken_prompt_queue"],
+            interrupt_event=interrupt_event,
+            setup_args=(should_listen,),
+            setup_kwargs=vars(self.kwargs["vad_handler_kwargs"]),
+        )
+        stt = ServiceFasterWhisperSTTHandler(
+            stop_event,
+            queue_in=q["spoken_prompt_queue"],
+            queue_out=q["text_prompt_queue"],
+            setup_kwargs=vars(self.kwargs["faster_whisper_stt_handler_kwargs"]),
+        )
+        lm = get_llm_handler(
+            self.kwargs["module_kwargs"],
+            stop_event,
+            q["text_prompt_queue"],
+            q["lm_response_queue"],
+            interrupt_event,
+            self.kwargs["language_model_handler_kwargs"],
+            self.kwargs["open_api_language_model_handler_kwargs"],
+            self.kwargs["mlx_language_model_handler_kwargs"],
+        )
+        tts = ServiceMeloTTSHandler(
+            stop_event,
+            queue_in=q["lm_response_queue"],
+            queue_out=q["send_audio_chunks_queue"],
+            interrupt_event=interrupt_event,
+            setup_args=(should_listen,),
+            setup_kwargs=vars(self.kwargs["melo_tts_handler_kwargs"]),
+        )
+        manager = ThreadManager([receiver, sender, aec, vad, stt, lm, tts])
+        manager.start()
+        for t in manager.threads:
+            t.join()
+        self.conn.close()
+
+
+def main():
+    args = parse_arguments()
+    prepare_all_args(*args)
+    module_kwargs = args[0]
+    host = "0.0.0.0"
+    port = 23456
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((host, port))
+    server.listen()
+    logger.info("Multi-user server listening on %s:%s", host, port)
+    try:
+        while True:
+            conn, _ = server.accept()
+            logger.info("New client connected")
+            ClientHandler(conn, args).start()
+    finally:
+        server.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ openai>=1.40.1
 triton==3.1.0
 livekit==1.0.8
 websockets==13.1
-rich==14.0.0
 aiohttp==3.12.6
 numpy==1.26.4
 rich==13.9.4

--- a/requirements_codex.txt
+++ b/requirements_codex.txt
@@ -1,0 +1,21 @@
+nltk==3.9.1
+lightning-whisper-mlx==0.0.10
+parler_tts @ git+https://github.com/newsbreakDuadua9/parler-tts
+melotts @ git+https://github.com/andimarafioti/MeloTTS.git#egg=MeloTTS  # made a copy of MeloTTS to have compatible versions of transformers
+torch==2.5.1
+torchaudio==2.5.1
+xformers==0.0.29
+sounddevice==0.5.0
+ChatTTS>=0.1.1
+funasr>=1.1.6
+faster-whisper>=1.0.3
+modelscope>=1.17.1
+deepfilternet>=0.5.6
+openai>=1.40.1
+triton==3.1.0
+livekit==1.0.8
+websockets==13.1
+aiohttp==3.12.6
+numpy==1.26.4
+rich==13.9.4
+useful-moonshine @ git+https://github.com/andimarafioti/moonshine.git

--- a/s2s_pipeline.py
+++ b/s2s_pipeline.py
@@ -209,6 +209,7 @@ def prepare_all_args(
 
 
 def initialize_queues_and_events():
+    """Create a fresh set of queues and events for one user session."""
     return {
         "stop_event": Event(),
         "interrupt_event": Event(),

--- a/services/stt_service.py
+++ b/services/stt_service.py
@@ -1,0 +1,66 @@
+import threading
+import queue
+import logging
+from typing import Callable, Any, Dict, Tuple
+
+from faster_whisper import WhisperModel
+
+logger = logging.getLogger(__name__)
+
+
+class WhisperService:
+    """Thread safe service wrapper around :class:`WhisperModel`.
+
+    A single model instance is shared across all ``WhisperService`` instances
+    created with the same configuration. Requests are processed asynchronously
+    by a dedicated worker thread.
+    """
+
+    _models: Dict[Tuple[str, str, str], WhisperModel] = {}
+    _lock = threading.Lock()
+
+    def __init__(self,
+                 model_name: str = "tiny.en",
+                 device: str = "auto",
+                 compute_type: str = "auto",
+                 gen_kwargs: Dict[str, Any] | None = None) -> None:
+        self.config = (model_name, device, compute_type)
+        self.gen_kwargs = gen_kwargs or {}
+        with self._lock:
+            if self.config not in self._models:
+                logger.info(f"Loading Whisper model {self.config}")
+                self._models[self.config] = WhisperModel(model_name,
+                                                         device=device,
+                                                         compute_type=compute_type)
+            self.model = self._models[self.config]
+
+        self._queue: "queue.Queue[Tuple[Any, Callable[[str], None]]]" = queue.Queue()
+        self._stop = threading.Event()
+        self._worker = threading.Thread(target=self._run, daemon=True)
+        self._worker.start()
+
+    def submit(self, audio: Any, callback: Callable[[str], None]) -> None:
+        """Submit ``audio`` for transcription.
+
+        ``callback`` is called with the resulting text once inference is done.
+        """
+        self._queue.put((audio, callback))
+
+    def close(self) -> None:
+        self._stop.set()
+        self._worker.join()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                audio, cb = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            try:
+                segments, _ = self.model.transcribe(audio, **self.gen_kwargs)
+                text = " ".join(s.text for s in segments).strip()
+                cb(text)
+            except Exception:  # pragma: no cover - logging only
+                logger.exception("WhisperService callback failed")
+            finally:
+                self._queue.task_done()

--- a/services/tts_service.py
+++ b/services/tts_service.py
@@ -1,0 +1,65 @@
+import threading
+import queue
+import logging
+from typing import Callable, Any, Dict, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class TTSService:
+    """Generic thread safe service for Text To Speech models."""
+
+    _models: Dict[Tuple[str, Tuple[Any, ...], Tuple[Tuple[str, Any], ...]], Any] = {}
+    _lock = threading.Lock()
+
+    def __init__(self,
+                 model_key: str,
+                 loader: Callable[[], Any],
+                 generate_fn: Callable[[Any, str], Any]):
+        """Create or reuse a model instance.
+
+        Parameters
+        ----------
+        model_key:
+            Unique key identifying the model configuration.
+        loader:
+            Function used to instantiate the model if not already loaded.
+        generate_fn:
+            Function taking ``(model, text)`` and returning audio data.
+        """
+        self.generate_fn = generate_fn
+        with self._lock:
+            if model_key not in self._models:
+                logger.info(f"Loading TTS model {model_key}")
+                self._models[model_key] = loader()
+            self.model = self._models[model_key]
+
+        self._queue: "queue.Queue[Tuple[str, Callable[[Any], None]]]" = queue.Queue()
+        self._stop = threading.Event()
+        self._worker = threading.Thread(target=self._run, daemon=True)
+        self._worker.start()
+
+    def submit(self, text: str, callback: Callable[[Any], None]) -> None:
+        """Submit ``text`` for synthesis.
+
+        ``callback`` is called with the generated audio when ready.
+        """
+        self._queue.put((text, callback))
+
+    def close(self) -> None:
+        self._stop.set()
+        self._worker.join()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                text, cb = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            try:
+                audio = self.generate_fn(self.model, text)
+                cb(audio)
+            except Exception:  # pragma: no cover - logging only
+                logger.exception("TTSService callback failed")
+            finally:
+                self._queue.task_done()


### PR DESCRIPTION
## Summary
- implement shared handlers `ServiceFasterWhisperSTTHandler` and `ServiceMeloTTSHandler`
- expose multi-user server `multi_user_server.py`
- provide simple connection helpers
- document multi-user server and ensure per-user queues/events

## Testing
- `pytest -q` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d5bdb75e4832f941d7d1c2074ffbc